### PR TITLE
Pardiso wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+#Ignore all object files
+*.o
+
+#Ignore all .mod files
+*.mod
+
+#Ignore all .so files
+*.so
+
+#Ignore all executables
+*.exe
+
+#Ignore all pdfs
+*.pdf
+
+#Ignore vim files:
+*~
+*.swp
+*.swo
+
+#Ignore __pycache__ directories
+**/__pycache__/
+
+#Ignore .vscode directory
+**/.vscode/

--- a/src/PARDISO_wrapper.py
+++ b/src/PARDISO_wrapper.py
@@ -1,0 +1,31 @@
+import numpy as np
+import scipy.sparse as sp
+import time
+
+from mod_PARDISO import mod_pardiso
+
+class PARDISO_wrapper:
+    #A class that wraps a fortran module for using MKL_PARDISO
+    def __init__(self,H_fl):
+        self.H_fl = H_fl
+
+        print('')
+        print('Setting up PARDISO and factorizing')
+        t_1 = time.perf_counter()
+        mod_pardiso.setup(self.H_fl.data,self.H_fl.indptr,self.H_fl.indices)
+        t_2 = time.perf_counter()
+        print('Done!')
+        print(f'Time for PARDISO setup and factorization: {t_2-t_1} s')
+        print('')
+
+        return
+
+    def solve(self,b):
+        x = np.zeros(self.H_fl.shape[0],dtype = np.complex128)
+
+        mod_pardiso.solve(self.H_fl.data,self.H_fl.indptr,self.H_fl.indices,x,b)
+
+        return x
+
+    def cleanup(self):
+        mod_pardiso.cleanup()

--- a/src/class_PARDISO.f90
+++ b/src/class_PARDISO.f90
@@ -1,0 +1,103 @@
+include 'mkl_pardiso.f90'
+module class_PARDISO
+    use mkl_pardiso
+    implicit none
+
+    type,public :: PARDISO_solver
+        type(MKL_PARDISO_HANDLE), dimension(:), allocatable  :: pt !Pointers used by PARDISO
+        integer, dimension(:), allocatable :: iparm !PARDISO parameter array
+        integer :: maxfct, mnum, mtype, phase, n, nrhs, error, msglvl, nnz !PARDISO integer parameters
+        integer, dimension(1) :: idum !dummy integer array
+        double complex, dimension(1) :: ddum !dummy complex array
+
+        contains
+        procedure :: setup => PARDISO_setup
+        procedure :: solve => PARDISO_solve
+        procedure :: cleanup => PARDISO_cleanup
+    end type PARDISO_solver
+
+contains
+    subroutine PARDISO_setup(this,n,nnz,a,ia,ja)
+        class(PARDISO_solver), intent(inout) :: this
+        integer, intent(in) :: n,nnz
+        double complex, dimension(0:nnz-1), intent(in) :: A
+        integer, dimension(0:n), intent(in) :: ia
+        integer, dimension(0:nnz-1), intent(in) :: ja
+
+        integer :: i !loop index
+
+
+        this%n = n
+        this%nnz = nnz
+        this%nrhs = 1 !Hard code this for now, could change later
+
+        this%error  = 0 !initialize error flag
+        this%msglvl = 0 !print no statistical information
+        this%mtype  = 13 !complex nonsymmetric
+        this%maxfct = 1 !Maximum number of factors
+        this%mnum = 1 !Number of matrix to solve
+
+
+        !.. Initialize the internal solver memory pointer. This is only
+        ! necessary for the FIRST call of the PARDISO solver.
+        allocate (this%pt(64))
+        do i = 1, 64
+            this%pt(i)%dummy =  0
+        end do
+
+        !..
+        !.. Set up PARDISO control parameters
+        !..
+        allocate(this%iparm(64))
+        do i = 1, 64
+            this%iparm(i) = 0
+        end do
+
+        !Please see the intel MKL online documentation for PARDISO for the complete meaning of all params
+        this%iparm(1) = 1 !Do not use defaults for all iparm
+        this%iparm(2) = 3 !Parallel fill in reordering
+        this%iparm(10) = 13 !Perturbation of small pivots by 1e-13
+        this%iparm(11) = 1 !Enable scaling vectors
+        this%iparm(13) = 1 !Enable weighted matching
+        this%iparm(24) = 0 !Change to 10 for two-level factorization (must disable param 11 and 13 if used)
+        this%iparm(27) = 0 !Enable matrix checker, could be useful for debugging, but probably disable later
+        this%iparm(35) = 1 !Use zero-based indexing, since arrays are comming from Python
+
+        this%phase = 12 !Analysis + numerical factorization
+        call pardiso (this%pt, this%maxfct, this%mnum, this%mtype, this%phase, this%n, a, ia, ja, &
+              this%idum, this%nrhs, this%iparm, this%msglvl, this%ddum, this%ddum, this%error)
+
+        if (this%error.ne.0) then
+            write(6,*) 'PARDISO setup error: ', this%error
+        end if
+
+    end subroutine PARDISO_setup
+
+    subroutine PARDISO_solve(this,a,ia,ja,x,b)
+        class(PARDISO_solver), intent(inout) :: this
+        double complex, dimension(0:this%nnz-1), intent(in) :: a
+        integer, dimension(0:this%n), intent(in) :: ia
+        integer, dimension(0:this%nnz-1), intent(in) :: ja
+        double complex, dimension(0:this%n-1), intent(inout) :: x,b
+
+        this%phase = 33 !Compute solution
+        call pardiso (this%pt, this%maxfct, this%mnum, this%mtype, this%phase, this%n, a, ia, ja, &
+              this%idum, this%nrhs, this%iparm, this%msglvl, b, x, this%error)
+
+        if (this%error.ne.0) then
+            write(6,*) 'PARDISO solve error: ', this%error
+        end if
+
+    end subroutine PARDISO_solve
+
+    subroutine PARDISO_cleanup(this)
+        class(PARDISO_solver), intent(inout) :: this
+
+        this%phase = -1 !Release internal memory for solver
+        call pardiso (this%pt, this%maxfct, this%mnum, this%mtype, this%phase, this%n, this%ddum, this%idum, this%idum, &
+              this%idum, this%nrhs, this%iparm, this%msglvl, this%ddum, this%ddum, this%error)
+
+        deallocate(this%pt,this%iparm)
+
+    end subroutine PARDISO_cleanup
+end module class_PARDISO

--- a/src/mod_PARDISO.f90
+++ b/src/mod_PARDISO.f90
@@ -1,0 +1,33 @@
+module mod_PARDISO
+    use class_PARDISO
+    implicit none
+    private
+    type(PARDISO_solver) :: solver
+
+    public :: setup, solve, cleanup
+
+    contains
+        subroutine setup(n,nnz,a,ia,ja)
+            integer, intent(in) :: n,nnz
+            double complex, dimension(0:nnz-1), intent(in) :: a
+            integer, dimension(0:n), intent(in) :: ia
+            integer, dimension(0:nnz-1), intent(in) :: ja
+
+            !Think about adding support for low-rank updates, since sparsity pattern never really changes.
+            call solver%setup(n,nnz,a,ia,ja)
+        end subroutine setup
+
+        subroutine solve(n,nnz,a,ia,ja,x,b)
+            integer, intent(in) :: n,nnz
+            double complex, dimension(0:nnz-1), intent(in) :: a
+            integer, dimension(0:n), intent(in) :: ia
+            integer, dimension(0:nnz-1), intent(in) :: ja
+            double complex, dimension(0:n-1), intent(inout) :: x,b
+
+            call solver%solve(a,ia,ja,x,b)
+        end subroutine solve
+
+        subroutine cleanup()
+            call solver%cleanup()
+        end subroutine cleanup
+end module mod_PARDISO

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -45,7 +45,10 @@ class Simulation:
             print(f'plot: {plot}')
             print(f'store_vecs: {store_vecs}')
 
-            use_fortran = self.read_line(file)
+            factor_options = self.read_line(file).split()
+            form_H_fl = factor_options[0]
+            use_fortran = factor_options[1]
+            print(f'form_H_fl: {form_H_fl}')
             print(f'use_fortran: {use_fortran}')
 
 
@@ -63,6 +66,13 @@ class Simulation:
             self.store_vecs = False
         else:
             print(f'Unknown store_vecs value {store_vecs}, please use \'t\' or \'f\'')
+
+        if form_H_fl == 't':
+            self.form_H_fl = True
+        elif form_H_fl == 'f':
+            self.form_H_fl = False
+        else:
+            print(f'Unknown form_H_fl value {form_H_fl}, please use \'t\' or \'f\'')
 
         if use_fortran == 't':
             self.use_fortran = True
@@ -170,7 +180,8 @@ class Simulation:
 
         for index,omega in np.ndenumerate(omega_vec):
             self.eigs[index[0],:],self.vecs[:,index[0]:index[0] + self.N_eigenvalues],self.max_block[index[0],:] = Floquet(omega,E_0,self.H,self.z,self.N_blocks_up,self.N_blocks_down,
-                                                                                        energy = self.shift,plot = self.plot,N_eig = self.N_eigenvalues, fortran = self.use_fortran)
+                                                                                        energy = self.shift,plot = self.plot,N_eig = self.N_eigenvalues, fortran = self.use_fortran,
+                                                                                        form_H_fl = self.form_H_fl)
 
         print('')
         print('The calculations have finished!')
@@ -196,7 +207,8 @@ class Simulation:
 
         for index,E_0 in np.ndenumerate(E_0_vec):
             self.eigs[index[0],:],self.vecs[:,index[0]:index[0] + self.N_eigenvalues],self.max_block[index[0],:] = Floquet(omega,E_0,self.H,self.z,self.N_blocks_up,self.N_blocks_down,
-                                                                                        energy = self.shift,plot = self.plot,N_eig = self.N_eigenvalues, fortran = self.use_fortran)
+                                                                                        energy = self.shift,plot = self.plot,N_eig = self.N_eigenvalues, fortran = self.use_fortran,
+                                                                                        form_H_fl = self.form_H_fl)
 
         print('')
         print('The calculations have finished!')
@@ -224,7 +236,7 @@ class Simulation:
             omega = omega_vec[index[0]]
             self.eigs[index[0],:],self.vecs[:,index[0]:index[0] + self.N_eigenvalues],self.max_block[index[0],:] = Floquet(omega,E_0,self.H,self.z,self.N_blocks_up,self.N_blocks_down,
                                                                                         energy = self.shift,plot = self.plot,N_eig = self.N_eigenvalues,sort_type = 'abs',
-                                                                                        fortran = self.use_fortran)
+                                                                                        fortran = self.use_fortran, form_H_fl = self.form_H_fl)
 
         print('')
         print('The calculations have finished!')
@@ -248,14 +260,14 @@ class Simulation:
 
         self.eigs[0,:],self.vecs[:,:self.N_eigenvalues],self.max_block[0,:] = Floquet(omega_vec[0],E_0,self.H,self.z,self.N_blocks_up,self.N_blocks_down,
                                                                                         energy = self.shift,plot = self.plot,N_eig = self.N_eigenvalues, 
-                                                                                        fortran = self.use_fortran)
+                                                                                        fortran = self.use_fortran, form_H_fl = self.form_H_fl)
 
         for index,omega in np.ndenumerate(omega_vec[1:]):
             for eig_index,eig in np.ndenumerate(self.eigs[index[0],:]): 
                 #Here I set n_eig = 4 since I am only interested in one eigenvalue (could maybe use less?)
                 eigs,vecs,blocks = Floquet(omega,E_0,self.H,self.z,self.N_blocks_up,self.N_blocks_down,
                                           energy = eig,plot = self.plot,N_eig = 4,sort_type = 'abs',
-                                          fortran = self.use_fortran)
+                                          fortran = self.use_fortran, form_H_fl = self.form_H_fl)
                 self.eigs[index[0]+1,eig_index[0]] = eigs[0] 
                 self.vecs[:,index[0]+1 + eig_index[0]] = vecs[:,0]
                 self.max_block[index[0]+1,eig_index[0]] = blocks[0]
@@ -283,14 +295,14 @@ class Simulation:
 
         self.eigs[0,:],self.vecs[:,:self.N_eigenvalues],self.max_block[0,:] = Floquet(omega,E_0_vec[0],self.H,self.z,self.N_blocks_up,self.N_blocks_down,
                                                                                         energy = self.shift,plot = self.plot,N_eig = self.N_eigenvalues,
-                                                                                        fortran = self.use_fortran)
+                                                                                        fortran = self.use_fortran, form_H_fl = self.form_H_fl)
         
         for index,E_0 in np.ndenumerate(E_0_vec[1:]):
             for eig_index,eig in np.ndenumerate(self.eigs[index[0],:]): 
                 #Here I set n_eig = 4 since I am only interested in one eigenvalue (could maybe use less?)
                 eigs,vecs,blocks = Floquet(omega,E_0,self.H,self.z,self.N_blocks_up,self.N_blocks_down,
                         energy = eig,plot = self.plot,N_eig = 4,sort_type = 'abs',prev_vec = self.vecs[:,index[0]+eig_index[0]],
-                        fortran = self.use_fortran)
+                        fortran = self.use_fortran, form_H_fl = self.form_H_fl)
                 self.eigs[index[0]+1,eig_index[0]] = eigs[0] 
                 self.vecs[:,index[0]+1 + eig_index[0]] = vecs[:,0]
                 self.max_block[index[0]+1,eig_index[0]] = blocks[0]
@@ -322,7 +334,7 @@ class Simulation:
 
         self.eigs[0,:],self.vecs[:,:self.N_eigenvalues],self.max_block[0,:] = Floquet(omega_vec[0],E_0_vec[0],self.H,self.z,self.N_blocks_up,self.N_blocks_down,
                                                                                         energy = self.shift,plot = self.plot,N_eig = self.N_eigenvalues,
-                                                                                        fortran = self.use_fortran)
+                                                                                        fortran = self.use_fortran, form_H_fl = self.form_H_fl)
         
         for index,E_0 in np.ndenumerate(E_0_vec[1:]):
             omega = omega_vec[index[0]+1]
@@ -330,7 +342,7 @@ class Simulation:
                 #Here I set n_eig = 4 since I am only interested in one eigenvalue (could maybe use less?)
                 eigs,vecs,blocks = Floquet(omega,E_0,self.H,self.z,self.N_blocks_up,self.N_blocks_down,
                         energy = eig,plot = self.plot,N_eig = 4,sort_type = 'abs',prev_vec = self.vecs[:,index[0]+eig_index[0]],
-                        fortran = self.use_fortran)
+                        fortran = self.use_fortran, form_H_fl = self.form_H_fl)
                 self.eigs[index[0]+1,eig_index[0]] = eigs[0] 
                 self.vecs[:,index[0]+1 + eig_index[0]] = vecs[:,0]
                 self.max_block[index[0]+1,eig_index[0]] = blocks[0]


### PR DESCRIPTION
- Added a wrapper to the MKL_PARDISO sparse solver
- Added an option to input to form H_FL and use sparse solvers instead of Block-LU factorization
- Added a .gitignore file

PARDISO is working, but the accuracy when using many Floquet blocks is not particularly good (compared to scipy.sparse.linalg.splu which uses the SuperLU library and always has good accuracy, but this option is much slower in the factorization).