### PR TITLE
PARDISO mtype

### DIFF
--- a/src/cis_Floquet.py
+++ b/src/cis_Floquet.py
@@ -89,7 +89,7 @@ def Floquet(omega,E_0,H,z,N_blocks_up,N_blocks_down,**kwargs):
         print('----------------------------------------')
 
         if fortran:
-            H_fl_PARDISO = PARDISO_wrapper(H_fl)
+            H_fl_PARDISO = PARDISO_wrapper(sp.triu(H_fl,format='csr'))
             H_fl_invop = spl.LinearOperator(H_fl.shape, matvec = H_fl_PARDISO.solve, dtype = np.complex128)
         else:
             print('')

--- a/src/cis_Floquet.py
+++ b/src/cis_Floquet.py
@@ -74,7 +74,7 @@ def Floquet(omega,E_0,H,z,N_blocks_up,N_blocks_down,**kwargs):
                 H_fl[i*N_elements:(i+1)*N_elements,(i+1)*N_elements:(i+2)*N_elements] = z_test*E_0/2
                 H_fl[(i+1)*N_elements:(i+2)*N_elements,i*N_elements:(i+1)*N_elements] = z_test*E_0/2
 
-        #PARDISO wants CSR and spl.spilu wants CSC
+        #PARDISO wants CSR and spl.splu wants CSC
         if fortran:
             H_fl = sp.csr_matrix(H_fl)
         else:

--- a/src/class_PARDISO.f90
+++ b/src/class_PARDISO.f90
@@ -33,7 +33,7 @@ contains
 
         this%error  = 0 !initialize error flag
         this%msglvl = 0 !print no statistical information
-        this%mtype  = 13 !complex nonsymmetric
+        this%mtype  = 6 !complex symmetric
         this%maxfct = 1 !Maximum number of factors
         this%mnum = 1 !Number of matrix to solve
 
@@ -56,10 +56,11 @@ contains
         !Please see the intel MKL online documentation for PARDISO for the complete meaning of all params
         this%iparm(1) = 1 !Do not use defaults for all iparm
         this%iparm(2) = 3 !Parallel fill in reordering
-        this%iparm(10) = 13 !Perturbation of small pivots by 1e-13
-        this%iparm(11) = 1 !Enable scaling vectors
-        this%iparm(13) = 1 !Enable weighted matching
-        this%iparm(24) = 0 !Change to 10 for two-level factorization (must disable param 11 and 13 if used)
+        this%iparm(10) = 8 !Perturbation of small pivots by 1e-8
+        this%iparm(11) = 0 !1: Enable scaling vectors
+        this%iparm(13) = 0 !1: Enable weighted matching
+        this%iparm(21) = 1 !Enable Bunch-Kaufman pivoting for complex symmetric matrix
+        this%iparm(24) = 10 !Change to 10 for two-level factorization (must disable param 11 and 13 if used)
         this%iparm(27) = 0 !Enable matrix checker, could be useful for debugging, but probably disable later
         this%iparm(35) = 1 !Use zero-based indexing, since arrays are comming from Python
 


### PR DESCRIPTION
- Update the mtype used in PARDISO to complex symmetric, which requires less work to factorize (and in the future also to set up)
- This also updates the size of the perturbation of pivot elements from 1e-13 to 1e-8 as recommended for this matrix type by the MKL PARDISO documentation. This seems to impact the stability of the factorization/solution positively. 